### PR TITLE
Fixed __getitem__ exception in Python 2.

### DIFF
--- a/ejdb/utils.py
+++ b/ejdb/utils.py
@@ -112,7 +112,7 @@ def read_ejdb_config():
     parser = ConfigParser()
     parser.read([os.path.expanduser('~/.ejdb.cfg'), config_path])
     try:
-        return parser['ejdb']['path']
+        return parser.get('ejdb', 'path')
     except KeyError:
         return None
 


### PR DESCRIPTION
__getitem__ of ConfigParser is not supported in Python 2. Following exception will be shown.

```
AttributeError: SafeConfigParser instance has no attribute '__getitem__'
```

Use get() for backward compatibility.
