### PR TITLE
Provide better EJDB binary loading processing.

### DIFF
--- a/ejdb/c.py
+++ b/ejdb/c.py
@@ -232,6 +232,9 @@ def init(ejdb_path=None):
         or read_ejdb_config()
         or ctypes.util.find_library('ejdb')
     )
+    
+    if not ejdb_path:
+        raise RuntimeError('EJDB binary not found')
 
     # Access to the C library.
     _ = ctypes.cdll.LoadLibrary(ejdb_path)

--- a/ejdb/utils.py
+++ b/ejdb/utils.py
@@ -8,9 +8,9 @@ import weakref
 import six
 
 try:
-    from configparser import ConfigParser
+    from configparser import ConfigParser, NoSectionError, NoOptionError
 except ImportError:     # Python 2.
-    from ConfigParser import SafeConfigParser as ConfigParser
+    from ConfigParser import SafeConfigParser as ConfigParser, NoSectionError, NoOptionError
 
 
 # Keeps a reference to all wrapper instances so that we can dealloc them when
@@ -113,7 +113,7 @@ def read_ejdb_config():
     parser.read([os.path.expanduser('~/.ejdb.cfg'), config_path])
     try:
         return parser.get('ejdb', 'path')
-    except KeyError:
+    except NoSectionError, NoOptionError:
         return None
 
 

--- a/ejdb/utils.py
+++ b/ejdb/utils.py
@@ -112,7 +112,7 @@ def read_ejdb_config():
     parser = ConfigParser()
     parser.read([os.path.expanduser('~/.ejdb.cfg'), config_path])
     try:
-        return parser['ejdb']['path']
+        return parser.get('ejdb', 'path')
     except KeyError:
         return None
 


### PR DESCRIPTION
- Fixed incompatible issue of ConfigParser.
- Provide meaningful runtime error when no valid EJDB binary path can be found.
